### PR TITLE
Create subsamplers, initial mode-median

### DIFF
--- a/site/src/_config.yml
+++ b/site/src/_config.yml
@@ -1,4 +1,4 @@
-component-ids: [introduction, chart, series, indicator, scale, svg, annotation, tool, layout, util, data]
+component-ids: [introduction, chart, series, indicator, scale, svg, annotation, tool, layout, util, data, samplers]
 
 components:
   introduction:
@@ -23,6 +23,8 @@ components:
     name: Util
   data:
     name: Data
+  samplers:
+    name: Samplers
 
 example-ids: [examples]
 

--- a/site/src/components/samplers/modeMedian.md
+++ b/site/src/components/samplers/modeMedian.md
@@ -5,14 +5,19 @@ component: data/samplers/modeMedian.js
 namespace: samplers
 
 example-code: |
-    var data = fc.data.random.financial()(10000);
+    var data = fc.data.random.financial()(20);
 
-    var subsampledData = fc.data.samplers.modeMedian()
-                                         .number(5)
-                                         .field('low')(data);
+    var sampler = fc.data.samplers.modeMedian()
+                                  .number(5)
+                                  .value(function(d) { return d.low; });
+
+    var sampledData = sampler(data);
 
     d3.select('#subsampled-data')
-      .text(JSON.stringify(subsampledData, null, 2));
+      .text(JSON.stringify(sampledData, null, 2));
+
+    d3.select('#full-data')
+      .text(JSON.stringify(data, null, 2));
 
 ---
 
@@ -24,9 +29,14 @@ The example below creates large array of data points, reducing it to 5.
 {{{example-code}}}
 ```
 
-Which gives the following:
+Which gives the following subsampled data:
 
 <pre id="subsampled-data">Loading...</pre>
+
+...when given the following data:
+
+<pre id="full-data">Loading...</pre>
+
 <script type="text/javascript">
     (function() {
         {{{example-code}}}

--- a/site/src/components/samplers/modeMedian.md
+++ b/site/src/components/samplers/modeMedian.md
@@ -1,0 +1,35 @@
+---
+layout: component
+title: Mode Median Sampling
+component: data/samplers/modeMedian.js
+namespace: samplers
+
+example-code: |
+    var data = fc.data.random.financial()(10000);
+
+    var subsampledData = fc.data.samplers.modeMedian()
+                                         .number(5)
+                                         .field('low')(data);
+
+    d3.select('#subsampled-data')
+      .text(JSON.stringify(subsampledData, null, 2));
+
+---
+
+The mode-median sampling component is a fast method of subsampling data to improve performance with large data sets.
+
+The example below creates large array of data points, reducing it to 5.
+
+```js
+{{{example-code}}}
+```
+
+Which gives the following:
+
+<pre id="subsampled-data">Loading...</pre>
+<script type="text/javascript">
+    (function() {
+        {{{example-code}}}
+    })();
+</script>
+

--- a/site/src/components/samplers/modeMedian.md
+++ b/site/src/components/samplers/modeMedian.md
@@ -5,41 +5,37 @@ component: data/samplers/modeMedian.js
 namespace: samplers
 
 example-code: |
-    var data = fc.data.random.financial()(20);
+    var data = fc.data.random.financial()(1000);
 
     var sampler = fc.data.samplers.modeMedian()
-                                  .number(5)
+                                  .bucketSize(20)
                                   .value(function(d) { return d.low; });
 
     var sampledData = sampler(data);
 
-    d3.select('#subsampled-data')
-      .text(JSON.stringify(sampledData, null, 2));
+    xScale.domain(fc.util.extent().fields('date')(sampledData))
+    yScale.domain(fc.util.extent().fields('low')(sampledData));
 
-    d3.select('#full-data')
-      .text(JSON.stringify(data, null, 2));
+    var line = fc.series.line();
+
+    line.xScale(xScale)
+        .yScale(yScale)
+        .yValue(function (d) { return d.low; });
+
+    container.append('g')
+             .datum(sampledData)
+             .call(line);
 
 ---
 
-The mode-median sampling component is a fast method of subsampling data to improve performance with large data sets.
+The mode-median sampling component is a method of subsampling data to improve performance with large data sets.
 
-The example below creates large array of data points, reducing it to 5.
+The example below creates large array of data points, reducing it to around 50.
 
 ```js
 {{{example-code}}}
 ```
 
-Which gives the following subsampled data:
+Which gives the following:
 
-<pre id="subsampled-data">Loading...</pre>
-
-...when given the following data:
-
-<pre id="full-data">Loading...</pre>
-
-<script type="text/javascript">
-    (function() {
-        {{{example-code}}}
-    })();
-</script>
-
+{{>example-fixture}}

--- a/src/data/data.js
+++ b/src/data/data.js
@@ -1,9 +1,11 @@
 import feed from './feed/feed';
 import random from './random/random';
+import samplers from './samplers/samplers';
 import spread from './spread';
 
 export default {
     feed: feed,
     random: random,
-    spread: spread
+    spread: spread,
+    samplers: samplers
 };

--- a/src/data/samplers/modeMedian.js
+++ b/src/data/samplers/modeMedian.js
@@ -3,18 +3,16 @@ import {identity, noop} from '../../util/fn';
 
 export default function() {
 
-    var undefinedValue = d3.functor(undefined),
-        number = d3.functor(10),
-        accumulator = noop,
-        field = identity;
+    var number = 10,
+        value = identity;
 
     var modeMedian = function(data) {
 
-        if (number() > data.length) {
+        if (number > data.length) {
             return data;
         }
 
-        var minMax = getGlobalMinMax(data);
+        var minMax = d3.extent(data);
         var buckets = getBuckets(data);
 
         var subsampledData = buckets.map(function(bucket, i) {
@@ -25,7 +23,7 @@ export default function() {
             var singleMostFrequent = true;
 
             for (var j = 0; j < bucket.length; j++) {
-                var item = field(bucket[j]);
+                var item = value(bucket[j]);
                 if (item === minMax[0] || item === minMax[1]) {
                     return bucket[j];
                 }
@@ -55,18 +53,8 @@ export default function() {
         return [].concat(data[0], subsampledData, data[data.length - 1]);
     };
 
-    var getGlobalMinMax = function(data) {
-        var min = Infinity;
-        var max = -Infinity;
-
-        min = d3.min(data, field);
-        max = d3.max(data, field);
-
-        return [min, max];
-    };
-
-    var getBuckets = function(data) {
-        var numberOfBuckets = number.apply(this, arguments) - 2;
+    function getBuckets(data) {
+        var numberOfBuckets = number - 2;
         var dataPointsPerBucket = (data.length - 2) / numberOfBuckets;
 
         // Use all but the first and last data points, as they are their own buckets.
@@ -77,28 +65,22 @@ export default function() {
             buckets.push(data.slice(1 + i * dataPointsPerBucket, 1 + (i + 1) * dataPointsPerBucket));
         }
         return buckets;
-    };
+    }
 
     modeMedian.number = function(x) {
         if (!arguments.length) {
             return number;
         }
-        number = d3.functor(x);
+        number = x;
         return modeMedian;
     };
 
-    modeMedian.field = function(x) {
+    modeMedian.value = function(x) {
         if (!arguments.length) {
-            return field;
+            return value;
         }
 
-        if (typeof x === 'string') {
-            field = function(d) {
-                return d[x];
-            };
-        } else {
-            field = x;
-        }
+        value = x;
 
         return modeMedian;
     };

--- a/src/data/samplers/modeMedian.js
+++ b/src/data/samplers/modeMedian.js
@@ -55,14 +55,13 @@ export default function() {
 
     function getBuckets(data) {
         var numberOfBuckets = Math.ceil((data.length - 2) / bucketSize);
-        var dataPointsPerBucket = (data.length - 2) / numberOfBuckets;
 
         // Use all but the first and last data points, as they are their own buckets.
         var trimmedData = data.slice(1, data.length - 1);
 
         var buckets = [];
         for (var i = 0; i < numberOfBuckets; i++) {
-            buckets.push(trimmedData.slice(i * dataPointsPerBucket, (i + 1) * dataPointsPerBucket));
+            buckets.push(trimmedData.slice(i * bucketSize, (i + 1) * bucketSize));
         }
         return buckets;
     }

--- a/src/data/samplers/modeMedian.js
+++ b/src/data/samplers/modeMedian.js
@@ -3,12 +3,12 @@ import {identity, noop} from '../../util/fn';
 
 export default function() {
 
-    var number = 10,
+    var bucketSize = 10,
         value = identity;
 
     var modeMedian = function(data) {
 
-        if (number > data.length) {
+        if (bucketSize > data.length) {
             return data;
         }
 
@@ -54,7 +54,7 @@ export default function() {
     };
 
     function getBuckets(data) {
-        var numberOfBuckets = number - 2;
+        var numberOfBuckets = Math.ceil((data.length - 2) / bucketSize);
         var dataPointsPerBucket = (data.length - 2) / numberOfBuckets;
 
         // Use all but the first and last data points, as they are their own buckets.
@@ -62,16 +62,16 @@ export default function() {
 
         var buckets = [];
         for (var i = 0; i < numberOfBuckets; i++) {
-            buckets.push(data.slice(1 + i * dataPointsPerBucket, 1 + (i + 1) * dataPointsPerBucket));
+            buckets.push(trimmedData.slice(i * dataPointsPerBucket, (i + 1) * dataPointsPerBucket));
         }
         return buckets;
     }
 
-    modeMedian.number = function(x) {
+    modeMedian.bucketSize = function(x) {
         if (!arguments.length) {
-            return number;
+            return bucketSize;
         }
-        number = x;
+        bucketSize = x;
         return modeMedian;
     };
 

--- a/src/data/samplers/modeMedian.js
+++ b/src/data/samplers/modeMedian.js
@@ -1,0 +1,107 @@
+import d3 from 'd3';
+import {identity, noop} from '../../util/fn';
+
+export default function() {
+
+    var undefinedValue = d3.functor(undefined),
+        number = d3.functor(10),
+        accumulator = noop,
+        field = identity;
+
+    var modeMedian = function(data) {
+
+        if (number() > data.length) {
+            return data;
+        }
+
+        var minMax = getGlobalMinMax(data);
+        var buckets = getBuckets(data);
+
+        var subsampledData = buckets.map(function(bucket, i) {
+
+            var frequencies = {};
+            var mostFrequent;
+            var mostFrequentIndex;
+            var singleMostFrequent = true;
+
+            for (var j = 0; j < bucket.length; j++) {
+                var item = field(bucket[j]);
+                if (item === minMax[0] || item === minMax[1]) {
+                    return bucket[j];
+                }
+
+                if (frequencies[item] === undefined) {
+                    frequencies[item] = 0;
+                }
+                frequencies[item]++;
+
+                if (frequencies[item] > frequencies[mostFrequent] || mostFrequent === undefined) {
+                    mostFrequent = item;
+                    mostFrequentIndex = j;
+                    singleMostFrequent = true;
+                } else if (frequencies[item] === frequencies[mostFrequent]) {
+                    singleMostFrequent = false;
+                }
+            }
+
+            if (singleMostFrequent) {
+                return bucket[mostFrequentIndex];
+            } else {
+                return bucket[Math.floor(bucket.length / 2)];
+            }
+        });
+
+        // First and last data points are their own buckets.
+        return [].concat(data[0], subsampledData, data[data.length - 1]);
+    };
+
+    var getGlobalMinMax = function(data) {
+        var min = Infinity;
+        var max = -Infinity;
+
+        min = d3.min(data, field);
+        max = d3.max(data, field);
+
+        return [min, max];
+    };
+
+    var getBuckets = function(data) {
+        var numberOfBuckets = number.apply(this, arguments) - 2;
+        var dataPointsPerBucket = (data.length - 2) / numberOfBuckets;
+
+        // Use all but the first and last data points, as they are their own buckets.
+        var trimmedData = data.slice(1, data.length - 1);
+
+        var buckets = [];
+        for (var i = 0; i < numberOfBuckets; i++) {
+            buckets.push(data.slice(1 + i * dataPointsPerBucket, 1 + (i + 1) * dataPointsPerBucket));
+        }
+        return buckets;
+    };
+
+    modeMedian.number = function(x) {
+        if (!arguments.length) {
+            return number;
+        }
+        number = d3.functor(x);
+        return modeMedian;
+    };
+
+    modeMedian.field = function(x) {
+        if (!arguments.length) {
+            return field;
+        }
+
+        if (typeof x === 'string') {
+            field = function(d) {
+                return d[x];
+            };
+        } else {
+            field = x;
+        }
+
+        return modeMedian;
+    };
+
+    return modeMedian;
+}

--- a/src/data/samplers/samplers.js
+++ b/src/data/samplers/samplers.js
@@ -1,0 +1,5 @@
+import modeMedian from './modeMedian';
+
+export default {
+    modeMedian: modeMedian
+};

--- a/tests/data/samplers/modeMedianSpec.js
+++ b/tests/data/samplers/modeMedianSpec.js
@@ -8,7 +8,7 @@ describe('fc.data.samplers.modeMedian', function() {
         beforeEach(function() {
             data = [0, 1, 6, 4, 8, 4, 8, 9, 3, 5, 2, 10, 2, 4, 3, 8, 5];
             bucketGenerator = fc.data.samplers.modeMedian()
-                                .field(function(d) { return d; });
+                                .value(function(d) { return d; });
         });
 
         it('should return original data if the number of buckets is longer than the data', function() {
@@ -42,44 +42,5 @@ describe('fc.data.samplers.modeMedian', function() {
             var subsampledData = bucketGenerator.number(5)(data);
             expect(subsampledData[2]).toEqual(3);
         });
-    });
-
-    describe('accessor data', function() {
-
-        beforeEach(function() {
-            data = [
-                {x: 1, y: 0},
-                {x: 2, y: 1},
-                {x: 3, y: 6},
-                {x: 4, y: 4},
-                {x: 5, y: 8},
-                {x: 6, y: 4},
-                {x: 7, y: 8},
-                {x: 8, y: 9},
-                {x: 9, y: 3},
-                {x: 10, y: 5},
-                {x: 11, y: 2},
-                {x: 12, y: 10},
-                {x: 13, y: 2},
-                {x: 14, y: 4}
-            ];
-        });
-
-        it('should use the accessor function provided', function() {
-            bucketGenerator = fc.data.samplers.modeMedian()
-                                .field(function(d) { return d.y; });
-            var subsampledData = bucketGenerator.number(4)(data);
-            expect(subsampledData[0].y).toEqual(0);
-            expect(subsampledData[2].y).toEqual(10);
-        });
-
-        it('should use the accessor string provided', function() {
-            bucketGenerator = fc.data.samplers.modeMedian()
-                                .field('y');
-            var subsampledData = bucketGenerator.number(4)(data);
-            expect(subsampledData[0].y).toEqual(0);
-            expect(subsampledData[2].y).toEqual(10);
-        });
-
     });
 });

--- a/tests/data/samplers/modeMedianSpec.js
+++ b/tests/data/samplers/modeMedianSpec.js
@@ -12,34 +12,34 @@ describe('fc.data.samplers.modeMedian', function() {
         });
 
         it('should return original data if the number of buckets is longer than the data', function() {
-            expect(bucketGenerator.number(100)(data))
+            expect(bucketGenerator.bucketSize(100)(data))
                 .toEqual(data);
         });
 
         it('should return the correct number of buckets if summarisation occurs', function() {
-            var subsampledData = bucketGenerator.number(5)(data);
+            var subsampledData = bucketGenerator.bucketSize(5)(data);
             expect(subsampledData.length).toEqual(5);
         });
 
         it('should have the first and last buckets be the first and last data points', function() {
-            var subsampledData = bucketGenerator.number(5)(data);
+            var subsampledData = bucketGenerator.bucketSize(5)(data);
             expect(subsampledData[0]).toEqual(0);
             expect(subsampledData[4]).toEqual(5);
         });
 
         it('should have 2 buckets with the global max and min', function() {
-            var subsampledData = bucketGenerator.number(5)(data);
+            var subsampledData = bucketGenerator.bucketSize(5)(data);
             expect(subsampledData[0]).toEqual(0);
             expect(subsampledData[3]).toEqual(10);
         });
 
         it('should return the most common number if there is one', function() {
-            var subsampledData = bucketGenerator.number(5)(data);
+            var subsampledData = bucketGenerator.bucketSize(5)(data);
             expect(subsampledData[1]).toEqual(4);
         });
 
         it('should return the middle data point if there is no mode', function() {
-            var subsampledData = bucketGenerator.number(5)(data);
+            var subsampledData = bucketGenerator.bucketSize(5)(data);
             expect(subsampledData[2]).toEqual(3);
         });
     });

--- a/tests/data/samplers/modeMedianSpec.js
+++ b/tests/data/samplers/modeMedianSpec.js
@@ -1,0 +1,85 @@
+describe('fc.data.samplers.modeMedian', function() {
+
+    var data;
+    var bucketGenerator;
+
+    describe('simple data', function() {
+
+        beforeEach(function() {
+            data = [0, 1, 6, 4, 8, 4, 8, 9, 3, 5, 2, 10, 2, 4, 3, 8, 5];
+            bucketGenerator = fc.data.samplers.modeMedian()
+                                .field(function(d) { return d; });
+        });
+
+        it('should return original data if the number of buckets is longer than the data', function() {
+            expect(bucketGenerator.number(100)(data))
+                .toEqual(data);
+        });
+
+        it('should return the correct number of buckets if summarisation occurs', function() {
+            var subsampledData = bucketGenerator.number(5)(data);
+            expect(subsampledData.length).toEqual(5);
+        });
+
+        it('should have the first and last buckets be the first and last data points', function() {
+            var subsampledData = bucketGenerator.number(5)(data);
+            expect(subsampledData[0]).toEqual(0);
+            expect(subsampledData[4]).toEqual(5);
+        });
+
+        it('should have 2 buckets with the global max and min', function() {
+            var subsampledData = bucketGenerator.number(5)(data);
+            expect(subsampledData[0]).toEqual(0);
+            expect(subsampledData[3]).toEqual(10);
+        });
+
+        it('should return the most common number if there is one', function() {
+            var subsampledData = bucketGenerator.number(5)(data);
+            expect(subsampledData[1]).toEqual(4);
+        });
+
+        it('should return the middle data point if there is no mode', function() {
+            var subsampledData = bucketGenerator.number(5)(data);
+            expect(subsampledData[2]).toEqual(3);
+        });
+    });
+
+    describe('accessor data', function() {
+
+        beforeEach(function() {
+            data = [
+                {x: 1, y: 0},
+                {x: 2, y: 1},
+                {x: 3, y: 6},
+                {x: 4, y: 4},
+                {x: 5, y: 8},
+                {x: 6, y: 4},
+                {x: 7, y: 8},
+                {x: 8, y: 9},
+                {x: 9, y: 3},
+                {x: 10, y: 5},
+                {x: 11, y: 2},
+                {x: 12, y: 10},
+                {x: 13, y: 2},
+                {x: 14, y: 4}
+            ];
+        });
+
+        it('should use the accessor function provided', function() {
+            bucketGenerator = fc.data.samplers.modeMedian()
+                                .field(function(d) { return d.y; });
+            var subsampledData = bucketGenerator.number(4)(data);
+            expect(subsampledData[0].y).toEqual(0);
+            expect(subsampledData[2].y).toEqual(10);
+        });
+
+        it('should use the accessor string provided', function() {
+            bucketGenerator = fc.data.samplers.modeMedian()
+                                .field('y');
+            var subsampledData = bucketGenerator.number(4)(data);
+            expect(subsampledData[0].y).toEqual(0);
+            expect(subsampledData[2].y).toEqual(10);
+        });
+
+    });
+});

--- a/visual-tests/index.html
+++ b/visual-tests/index.html
@@ -201,6 +201,14 @@
 
           </section>
           <section>
+            <h2>Subsampling</h2>
+
+            <article data-href="sampling/modeMedianBucket.html">
+              <h3>Mode-median Bucket</h3>
+              <p>Demonstrates subsampling 100,000 data points to 200</p>
+            </article>
+          </section>
+          <section>
             <h2>Tool</h2>
 
             <article data-href="tool/crosshair.html">

--- a/visual-tests/index.html
+++ b/visual-tests/index.html
@@ -203,8 +203,8 @@
           <section>
             <h2>Subsampling</h2>
 
-            <article data-href="sampling/modeMedianBucket.html">
-              <h3>Mode-median Bucket</h3>
+            <article data-href="sampling/modeMedian.html">
+              <h3>Mode-Median</h3>
               <p>Demonstrates subsampling 100,000 data points to 200</p>
             </article>
           </section>

--- a/visual-tests/indicator/modeMedianBucket.js
+++ b/visual-tests/indicator/modeMedianBucket.js
@@ -1,0 +1,32 @@
+(function(d3, fc) {
+    var dataPoints = 100000;
+    var compressedDataPoints = 1000;
+    var width = 600, height = 250;
+
+    var data = fc.data.random.walk()(dataPoints);
+    data = data.map(function(d, i) {
+        return {x: i, y: d};
+    });
+    var compressedData = fc.data.samplers.modeMedianBucket()
+                .number(compressedDataPoints).field('y')(data);
+
+    var chart = fc.chart.cartesian()
+        .xDomain(fc.util.extent().fields('x')(compressedData))
+        .yDomain(fc.util.extent().fields('y')(compressedData));
+
+    var gridlines = fc.annotation.gridline();
+    var line = fc.series.line().xValue('x').yValue('y');
+
+    var multi = fc.series.multi()
+        .series([gridlines, line]);
+    chart.plotArea(multi);
+
+    d3.select('#chart')
+        .append('svg')
+        .style({
+            height: height,
+            width: width
+        })
+        .datum(compressedData)
+        .call(chart);
+})(d3, fc);

--- a/visual-tests/sampling/modeMedian.html
+++ b/visual-tests/sampling/modeMedian.html
@@ -1,0 +1,23 @@
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Mode Median Bucket - d3fc Visual Tests</title>
+
+        <link href="../assets/d3fc.css" rel="stylesheet">
+        <link href="../assets/d3fc.css" rel="stylesheet">
+    </head>
+    <body>
+        <div id="chart"></div>
+        <footer>
+            <script src="../assets/d3.js"></script>
+            <script src="../assets/css-layout.js"></script>
+            <script src="../assets/d3fc.js"></script>
+            <script src="../assets/seedrandom.min.js"></script>
+            <script src="../setup.js"></script>
+            <script src="modeMedian.js"></script>
+            <script src="//localhost:35729/livereload.js"></script>
+        </footer>
+    </body>
+</html>

--- a/visual-tests/sampling/modeMedian.js
+++ b/visual-tests/sampling/modeMedian.js
@@ -1,6 +1,6 @@
 (function(d3, fc) {
-    var dataPoints = 1000000;
-    var subsampledDataPoints = 600;
+    var dataPoints = 100000;
+    var subsampledDataPoints = 200;
     var width = 600, height = 250;
 
     var data = fc.data.random.walk().steps(dataPoints)(5000);
@@ -9,7 +9,8 @@
     });
 
     var subsampledData = fc.data.samplers.modeMedian()
-                .number(subsampledDataPoints).value(function(d) { return d.y; })(data);
+                .bucketSize(dataPoints / subsampledDataPoints)
+                .value(function(d) { return d.y; })(data);
 
     var xScale = d3.scale.linear()
                     .domain(fc.util.extent().fields('x')(subsampledData))

--- a/visual-tests/sampling/modeMedian.js
+++ b/visual-tests/sampling/modeMedian.js
@@ -1,0 +1,35 @@
+(function(d3, fc) {
+    var dataPoints = 1000000;
+    var subsampledDataPoints = 600;
+    var width = 600, height = 250;
+
+    var data = fc.data.random.walk().steps(dataPoints)(5000);
+    data = data.map(function(d, i) {
+        return {x: i, y: d};
+    });
+
+    var subsampledData = fc.data.samplers.modeMedian()
+                .number(subsampledDataPoints).field('y')(data);
+
+    var xScale = d3.scale.linear()
+                    .domain(fc.util.extent().fields('x')(subsampledData))
+                    .range([0, width]);
+    var yScale = d3.scale.linear()
+                    .domain(fc.util.extent().fields('y')(subsampledData))
+                    .range([height, 0]);
+
+    var line = fc.series.line()
+                    .xScale(xScale)
+                    .yScale(yScale)
+                    .xValue(function(d) { return d.x; })
+                    .yValue(function(d) { return d.y; });
+
+    d3.select('#chart')
+        .append('svg')
+        .style({
+            height: height,
+            width: width
+        })
+        .datum(subsampledData)
+        .call(line);
+})(d3, fc);

--- a/visual-tests/sampling/modeMedian.js
+++ b/visual-tests/sampling/modeMedian.js
@@ -9,7 +9,7 @@
     });
 
     var subsampledData = fc.data.samplers.modeMedian()
-                .number(subsampledDataPoints).field('y')(data);
+                .number(subsampledDataPoints).value(function(d) { return d.y; })(data);
 
     var xScale = d3.scale.linear()
                     .domain(fc.util.extent().fields('x')(subsampledData))


### PR DESCRIPTION
Creates a new component of `d3fc.data`, `samplers`, which subsamples data in order to make rendering/processing large data sets easier.

The first subsampler is the _mode median_ subsampler, which looks at the mode and the median of a range of data sets.
